### PR TITLE
Fix escaping for code blocks

### DIFF
--- a/Feature.php
+++ b/Feature.php
@@ -25,6 +25,7 @@ readonly class Feature
         // `foo` => <code>foo</code>
         // \` => `
         // \\ => \
+        // Any character following \ other than ` and \ will get dropped!
 
         $output = $currentCode = '';
         $inCode = false;
@@ -35,7 +36,11 @@ readonly class Feature
 
             if ($escaped) {
                 $escaped = false;
-                $output .= $char;
+                if ($inCode) {
+                    $currentCode .= $char;
+                } else {
+                    $output .= $char;
+                }
                 continue;
             }
 

--- a/data.yaml
+++ b/data.yaml
@@ -669,7 +669,7 @@
   categories:
   - Warning
 
-- name: "Additions to `Random\\Randomizer`; add `Random\\IntervalBoundary`"
+- name: "Additions to `Random\\\\Randomizer`; add `Random\\\\IntervalBoundary`"
   version: "8.3"
   rfc: https://wiki.php.net/rfc/randomizer_additions
   docs: []


### PR DESCRIPTION
Yes, eventually this should use an actual markdown parser or something. In the meantime, this tweaks the backtick code block handling so that code containing escape sequences don't produce erroneous results.