### PR TITLE
Add dark mode support

### DIFF
--- a/index.php
+++ b/index.php
@@ -176,7 +176,8 @@ $features = array_map(function ($row) {
           background-color: #4F5B93;
         }
         </style>
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/base16/solarized-light.min.css" media="screen">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/base16/solarized-dark.min.css" media="screen and (prefers-color-scheme: dark)">
     </head>
 
     <body>

--- a/index.php
+++ b/index.php
@@ -35,21 +35,40 @@ $features = array_map(function ($row) {
     <head>
         <title>PHP Feature Versions</title>
         <style type="text/css">
+        :root {
+            --bg: #f7f6f2;
+            --table-stripe: #EEE;
+            --php-purple: #7A86B8;
+            --blue: #268bd2;
+            --violet: #6c71c4;
+        }
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #3b3936;
+                --table-stripe: #322e27;
+            }
+        }
+        
         * {
           margin: 0;
           padding: 0;
         }
+        a { color: var(--blue); }
+        a:visited { color: var(--violet); }
+        body {
+          background-color: var(--bg);
+        }
         table thead {
           position: sticky;
           top: 0;
-          background-color: #7A86B8;
+          background-color: var(--php-purple);
         }
         table thead th {
           padding: 0 0.5em;
         }
         /* zebra-stripe the table */
         table tr:nth-child(even) {
-          background-color: #EEE;
+          background-color: var(--table-stripe);
         }
         /* center the table */
         #root > table {

--- a/index.php
+++ b/index.php
@@ -36,27 +36,31 @@ $features = array_map(function ($row) {
         <title>PHP Feature Versions</title>
         <style type="text/css">
         :root {
-            --bg: #f7f6f2;
-            --table-stripe: #EEE;
-            --php-purple: #7A86B8;
-            --blue: #268bd2;
-            --violet: #6c71c4;
+          --bg: #f7f6f2;
+          --text: #000;
+          --table-stripe: #eee;
+          --php-purple: #7a86b8;
+          --blue: #268bd2;
+          --violet: #6c71c4;
         }
         @media (prefers-color-scheme: dark) {
-            :root {
-                --bg: #3b3936;
-                --table-stripe: #322e27;
-            }
+          :root {
+            --text: #eaeae9;
+            --bg: #3b3936;
+            --table-stripe: #322e27;
+          }
         }
         
         * {
           margin: 0;
           padding: 0;
+          font-family: sans-serif;
         }
         a { color: var(--blue); }
         a:visited { color: var(--violet); }
         body {
           background-color: var(--bg);
+          color: var(--text);
         }
         table thead {
           position: sticky;
@@ -65,6 +69,9 @@ $features = array_map(function ($row) {
         }
         table thead th {
           padding: 0 0.5em;
+        }
+        table tbody td {
+          padding: 0.15em 0;
         }
         /* zebra-stripe the table */
         table tr:nth-child(even) {


### PR DESCRIPTION
This makes some style adjustments to provide an alternate color scheme when the browser indicates that dark mode is the preferred color scheme:

- Convert some colors to CSS variables
- Add a media query to override some of those variables for dark mode
- Conditionally import a dark style for the code highlighter

In doing this, I found that the existing padding and default font are a bit hard to read in dark mode, so I also added just a tiny bit of padding (I want to maintain high information density!) and switched to `sans-serif`

I didn't convert the whole page to Solarized, but did use it as the highlightjs theme and used the blue and violet from it for link colors, which seemed a little less visually harsh than the browser defaults.