### PR TITLE
Reorganize data display

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: yaml
       - name: Checkout
         uses: actions/checkout@v3

--- a/Feature.php
+++ b/Feature.php
@@ -67,4 +67,23 @@ readonly class Feature
 
         return $output;
     }
+
+    public function renderLinks(): string
+    {
+        $out = [self::link($this->rfc, 'RFC')];
+        foreach ($this->docs as $doc) {
+            $out[] = self::link($doc, 'Docs');
+        }
+
+        return implode(', ', $out);
+    }
+
+    private static function link(string $to, string $text): string
+    {
+        return sprintf(
+            '<a href="%s" rel="noopener nofollow" target="_blank">%s</a>',
+            $to,
+            $text,
+        );
+    }
 }

--- a/Feature.php
+++ b/Feature.php
@@ -70,7 +70,10 @@ readonly class Feature
 
     public function renderLinks(): string
     {
-        $out = [self::link($this->rfc, 'RFC')];
+        $out = [];
+        if ($this->rfc !== '') {
+            $out[] = self::link($this->rfc, 'RFC');
+        }
         foreach ($this->docs as $doc) {
             $out[] = self::link($doc, 'Docs');
         }

--- a/Version.php
+++ b/Version.php
@@ -13,14 +13,8 @@ enum Version: string
     case v8_1 = '8.1';
     case v8_2 = '8.2';
     case v8_3 = '8.3';
+    case v8_4 = '8.4';
 
-    public function isActivelySupportedVersion(): bool
-    {
-        return match ($this) {
-            Version::v8_1 => true,
-            Version::v8_2 => true,
-            Version::v8_3 => true,
-            default => false,
-        };
-    }
+    public const CURRENT = [self::v8_1, self::v8_2, self::v8_3];
+    public const UPCOMING = self::v8_4;
 }

--- a/Version.php
+++ b/Version.php
@@ -17,4 +17,19 @@ enum Version: string
 
     public const CURRENT = [self::v8_1, self::v8_2, self::v8_3];
     public const UPCOMING = self::v8_4;
+
+    public function isAddedInCurrent(): bool
+    {
+        return in_array($this, self::CURRENT);
+    }
+
+    public function isUpcoming(): bool
+    {
+        return $this === self::UPCOMING;
+    }
+
+    public function isSupportedInVersion(Version $version): bool
+    {
+        return version_compare($this->value, $version->value, '>=');
+    }
 }

--- a/Version.php
+++ b/Version.php
@@ -13,4 +13,14 @@ enum Version: string
     case v8_1 = '8.1';
     case v8_2 = '8.2';
     case v8_3 = '8.3';
+
+    public function isActivelySupportedVersion(): bool
+    {
+        return match ($this) {
+            Version::v8_1 => true,
+            Version::v8_2 => true,
+            Version::v8_3 => true,
+            default => false,
+        };
+    }
 }

--- a/data.yaml
+++ b/data.yaml
@@ -2,7 +2,7 @@
   version: "8.4"
   docs: []
   categories: []
-  rfc: "#"
+  rfc: ""
 
 - name: scalar types, strict_types=1
   version: "7.0"

--- a/data.yaml
+++ b/data.yaml
@@ -1,3 +1,9 @@
+- name: Data for 8.4 features coming soon
+  version: "8.4"
+  docs: []
+  categories: []
+  rfc: "#"
+
 - name: scalar types, strict_types=1
   version: "7.0"
   rfc: https://wiki.php.net/rfc/scalar_type_hints_v5

--- a/index.php
+++ b/index.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+$start = hrtime(true);
+
 require __DIR__ . '/Version.php';
 require __DIR__ . '/Feature.php';
 
@@ -274,4 +276,8 @@ $features = array_map(function ($row) {
         </script>
     </body>
 </html>
+<?php
+$renderNs = hrtime(true) - $start;
+$renderMs = $renderNs / 1_000_000;
+echo '<!-- built in ' . round($renderMs, 3) . 'ms -->';
 

--- a/index.php
+++ b/index.php
@@ -78,9 +78,15 @@ $features = array_map(function ($row) {
           background-color: var(--table-stripe);
         }
         /* center the table */
-        #root > table {
-            margin: 0 auto;
-        }
+
+h1, h2 { text-align: center; line-height: 1.4;}
+body {
+}
+#root {
+display: flex;
+flex-direction: column;
+align-items: center;
+}
 
         /*!
          * "Fork me on GitHub" CSS ribbon v0.2.3 | MIT License
@@ -189,85 +195,73 @@ $features = array_map(function ($row) {
 
     <body>
         <a class="github-fork-ribbon" href="https://www.github.com/Firehed/phptools.win" data-ribbon="Edit me on GitHub" title="Edit me on GitHub" target="_blank">Edit me on GitHub</a>
-        <div id="root"></div>
+
+<div id="root">
+<h1>PHP Features by version</h1>
+<h2>Currently supported PHP versions</h2>
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Links</th>
+<?=implode('', array_map(fn ($v) => "<th>$v->value</th>", Version::CURRENT))?>
+        </tr>
+    </thead>
+    <tbody>
+<?php foreach (array_filter($features, fn ($f) => $f->version->isAddedInCurrent()) as $feature): ?>
+        <tr>
+            <td><?=$feature->name?></td>
+            <td><?=$feature->renderLinks()?></td>
+            <?php foreach (Version::CURRENT as $version): ?>
+                <td><?=$feature->version->isSupportedInVersion($version) ? 'Y' : ''?>
+            <?php endforeach; ?>
+        </tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+
+<h2>Next release (<?=Version::UPCOMING->value?>)</h2>
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Links</th>
+        </tr>
+    </thead>
+    <tbody>
+<?php foreach (array_filter($features, fn ($f) => $f->version->isSupportedInVersion(Version::UPCOMING)) as $feature): ?>
+        <tr>
+            <td><?=$feature->name?></td>
+            <td><?=$feature->renderLinks()?></td>
+        </tr>
+<?php endforeach; ?>
+    </tbody>
+</table>
+
+
+<h2>Previously-introduced</h2>
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Links</th>
+            <th>Introduced</th>
+        </tr>
+    </thead>
+    <tbody>
+<?php foreach (array_filter($features, fn ($f) => !($f->version->isAddedInCurrent() || $f->version->isUpcoming())) as $feature): ?>
+        <tr>
+            <td><?=$feature->name?></td>
+            <td><?=$feature->renderLinks()?></td>
+            <td><?=$feature->version->value?></td>
+        </tr>
+<?php endforeach; ?>
+    </tbody>
+</table>
+</div>
+
         <footer>This site is not affiliated with PHP.net or The PHP Group</footer>
         <?=$buildFooter?>
-        <script type="text/javascript">
-const features = <?=json_encode($features)?>
-// https://www.php.net/manual/en/migration70.new-features.php
-// https://www.php.net/manual/en/migration71.new-features.php
-// https://www.php.net/manual/en/migration72.new-features.php
-// https://www.php.net/manual/en/migration73.new-features.php
-// https://www.php.net/manual/en/migration74.new-features.php
-// https://www.php.net/manual/en/migration80.new-features.php
-// https://www.php.net/manual/en/migration81.new-features.php
-// https://www.php.net/manual/en/migration82.new-features.php
-
-const makeRow = (values, el = 'td') => {
-    const tds = values.map(v => {
-        const td = document.createElement(el)
-        // td.innerHTML = v
-        if (typeof v === 'string') {
-            td.innerText = v
-        } else {
-            td.appendChild(v)
-        }
-        return td
-    })
-    const tr = document.createElement('tr')
-    tds.forEach(td => tr.appendChild(td))
-    return tr
-}
-
-const versions = Array.from(new Set(features.map(feat => feat.version))).sort()
-
-const root = document.getElementById('root')
-const table = document.createElement('table')
-root.appendChild(table)
-
-const thead = document.createElement('thead')
-thead.appendChild(makeRow(['Name', 'Links', ...versions], 'th'))
-table.appendChild(thead)
-
-const tbody = document.createElement('tbody')
-
-features.forEach(feature => {
-
-    // blah
-    const versionInfo = versions.map(version => version >= feature.version ? 'Y' : '')
-
-    // TODO: comma separation
-    const links = document.createElement('p')
-    if (feature.rfc !== '') {
-        const link = document.createElement('a')
-        link.innerText = 'RFC ↗️'
-        link.href = feature.rfc
-        link.rel = 'noopener nofollow'
-        link.target = '_blank'
-        links.appendChild(link)
-    }
-
-    feature.docs.forEach(docLink => {
-        const link = document.createElement('a')
-        link.innerText = 'Docs ↗️'
-        link.href = docLink,
-        link.rel = 'noopener nofollow'
-        link.target = '_blank'
-        links.appendChild(link)
-    })
-
-    const name = document.createElement('p')
-    name.innerHTML = feature.name
-
-    const row = makeRow([name, links, ...versionInfo])
-    tbody.appendChild(row)
-})
-table.appendChild(tbody)
-
-
-console.log(versions)
-// document.getElementById('data').innerHTML=JSON.stringify(features)
-        </script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
         <script type="text/javascript" >
         document.addEventListener('DOMContentLoaded', (event) => {

--- a/index.php
+++ b/index.php
@@ -77,16 +77,18 @@ $features = array_map(function ($row) {
         table tr:nth-child(even) {
           background-color: var(--table-stripe);
         }
-        /* center the table */
 
-h1, h2 { text-align: center; line-height: 1.4;}
-body {
-}
-#root {
-display: flex;
-flex-direction: column;
-align-items: center;
-}
+        h1, h2 {
+            text-align: center;
+        }
+        h2 {
+            margin-block: 1em;
+        }
+        #root {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
 
         /*!
          * "Fork me on GitHub" CSS ribbon v0.2.3 | MIT License


### PR DESCRIPTION
The version matrix has become very unwieldy with _nine_ different version columns, and a tenth to be added soon. This change reorganizes the data, highlighting only the versions with active support, and de-emphasizing those added in EOL versions.

Before:
![Screenshot 2024-08-14 at 3 43 27 PM](https://github.com/user-attachments/assets/ce1d5582-4fbb-4f84-bde2-f9dd7c16ce2e)

After:
![Screenshot 2024-08-14 at 3 43 35 PM](https://github.com/user-attachments/assets/d7a9a549-7da7-418f-adc5-c7be0059faa2)


The mess of javascript to render the data has been replaced by a mess of 1998-style inlined PHP.