### PR TITLE
Fix availability logic

### DIFF
--- a/Version.php
+++ b/Version.php
@@ -30,6 +30,6 @@ enum Version: string
 
     public function isSupportedInVersion(Version $version): bool
     {
-        return version_compare($this->value, $version->value, '>=');
+        return version_compare($this->value, $version->value, '<=');
     }
 }


### PR DESCRIPTION
The site was incorrectly showing 8.1 features unavailable in 8.2+, 8.3 features in all versions, etc. The culprit was a simple inverted comparison operator.