### PR TITLE
Bump GHA versions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,17 +34,21 @@ jobs:
           php-version: '8.3'
           extensions: yaml
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
+
       - name: Build html
         run: |
           mkdir build
           php index.php > build/index.html
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
           path: 'build'
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -45,10 +45,10 @@ jobs:
           php index.php > build/index.html
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'build'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: yaml
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
 
       - name: Build
         run: php index.php


### PR DESCRIPTION
Older versions of the pages upload workflow are deprecated and no longer work.

https://github.com/Firehed/phptools.win/actions/runs/17884184196